### PR TITLE
fix: make jump host optional

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ if [ -z "$SSH_PORT" ]; then
   SSH_PORT=22
 fi
 
-if [ -z "$SSH_JUMP_HOST" ]; then
+if [ -n "$SSH_JUMP_HOST" ]; then
     if [ -z "$SSH_JUMP_PUBLIC_KEY" ]; then
         echo "Input ssh_jump_public_key is required!"
         exit 1


### PR DESCRIPTION
fix a validation step that would fail every time if a jump host wasn't set